### PR TITLE
Revert "Bump uri from 1.0.3 to 1.0.4 in /docs"

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -289,7 +289,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
-    uri (1.0.4)
+    uri (1.0.3)
     webrick (1.9.1)
 
 PLATFORMS


### PR DESCRIPTION
Reverts theandyb/theandyb.github.io#3

Change breaks site